### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/packaged.yaml
+++ b/packaged.yaml
@@ -32,7 +32,7 @@ Resources:
     Properties:
       CodeUri: s3://iot-test-mo/a77eda41a5c53ec598f156d3c07e6936
       Handler: app.lambdaHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Environment:
         Variables:
           MQ_HOST:

--- a/template.yaml
+++ b/template.yaml
@@ -33,7 +33,7 @@ Resources:
     Properties:
       CodeUri: src/PublishMessage
       Handler: app.lambdaHandler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Environment:
         Variables:
           MQ_HOST: !Sub "${BasicBroker}-1.mq.${AWS::Region}.amazonaws.com"


### PR DESCRIPTION
CloudFormation templates in aws-sar-lambda-publish-amazonmq have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.